### PR TITLE
Removed some legacy references

### DIFF
--- a/returnn/datasets/basic.py
+++ b/returnn/datasets/basic.py
@@ -916,7 +916,7 @@ def init_dataset(kwargs, extra_kwargs=None, default_kwargs=None):
         if kwargs.startswith("{"):
             kwargs = eval(kwargs)
         else:
-            assert ValueError("Defining datasets via string is no longer allowed")
+            raise ValueError("Defining datasets via string is no longer allowed")
     assert isinstance(kwargs, dict)
     kwargs = kwargs.copy()
     assert "class" in kwargs

--- a/tools/bliss-to-ogg-zip.py
+++ b/tools/bliss-to-ogg-zip.py
@@ -444,7 +444,7 @@ def main():
 
 
 if __name__ == "__main__":
-    from returnn.util import better_exchook
+    import better_exchook
 
     better_exchook.install()
     try:

--- a/tools/dump-dataset.py
+++ b/tools/dump-dataset.py
@@ -244,7 +244,7 @@ def init(config_str, config_dataset, verbosity):
     else:
         print("Use train dataset from config.")
         assert config.value("train", None)
-        dataset = init_dataset(config.value("train", None)) #TODO: init_dataset with str argument is no longer allowed
+        dataset = init_dataset(config.value("train", None))
     rnn.init_log()
     print("Returnn dump-dataset starting up.", file=log.v2)
     rnn.returnn_greeting()

--- a/tools/dump-dataset.py
+++ b/tools/dump-dataset.py
@@ -217,7 +217,6 @@ def init(config_str, config_dataset, verbosity):
     """
     global dataset
     rnn.init_better_exchook()
-    rnn.init_thread_join_hack()
     dataset_dict = None
     config_filename = None
     if config_str.strip().startswith("{"):
@@ -245,13 +244,13 @@ def init(config_str, config_dataset, verbosity):
     else:
         print("Use train dataset from config.")
         assert config.value("train", None)
-        dataset = init_dataset("config:train")
+        dataset = init_dataset(config.value("train", None)) #TODO: init_dataset with str argument is no longer allowed
     rnn.init_log()
     print("Returnn dump-dataset starting up.", file=log.v2)
     rnn.returnn_greeting()
     rnn.init_faulthandler()
     print("Dataset:", file=log.v2)
-    print("  input:", dataset.num_inputs, "x", dataset.window, file=log.v2)
+    print("  input:", dataset.num_inputs, file=log.v2)
     print("  output:", dataset.num_outputs, file=log.v2)
     print(" ", dataset.len_info() or "no info", file=log.v2)
 


### PR DESCRIPTION
- In the `init_dataset` in `returnn/datasets/basic.py` the database no longer accepts just strings if they do not directly contain the config. This was checked but the corresponding  `ValueError` was asserted instead of raised, which did not lead to the job actually stopping. Instead in then crashed at the assertion `isinstace(kwargs, dict) in the next line.
- The `bliss-to-ogg-zip.py` still had a legacy import of `better_exchook`, which went over RETURNN, but the corresponding import in the `returnn/util` was not there anymore.
- In `dump-dataset.py` the call to `init_dataset` then needs to pass the config as a string instead just a reference to the config.
  - Additionally there was a legacy reference to `dataset.window`, which leads to crashing, since that parameter no longer exists.