### PR TITLE
Handle broken training

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -52,3 +52,4 @@ Added features that are likely to appear in mainline-RETURNN:
 Experimental features that might not be needed:
  - ``batching_drop_last`` config parameter to discard the last incomplete batch in an epoch
  - forward init/finish hooks that can be used to attach custom objects to the run_ctx
+ - ``allow_missing_optimizer`` config parameter to allow the usage of a fresh optimizer in case the optimizer checkpoint for the chosen epoch can't be found

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Current Master (0.1+git)
 ------------------------
 
 - provide ``epoch`` and ``step`` in ``RunCtx`` (`<https://github.com/JackTemaki/MiniReturnn/pull/4>`_)
+- ``allow_missing_optimizer_checkpoint`` config parameter to allow the usage of a fresh optimizer in case the optimizer checkpoint for the chosen epoch can't be found
 
 Version 0.1
 -----------
@@ -52,4 +53,3 @@ Added features that are likely to appear in mainline-RETURNN:
 Experimental features that might not be needed:
  - ``batching_drop_last`` config parameter to discard the last incomplete batch in an epoch
  - forward init/finish hooks that can be used to attach custom objects to the run_ctx
- - ``allow_missing_optimizer`` config parameter to allow the usage of a fresh optimizer in case the optimizer checkpoint for the chosen epoch can't be found

--- a/returnn/torch/engine.py
+++ b/returnn/torch/engine.py
@@ -523,7 +523,10 @@ class Engine(EngineBase):
         :param int epoch: Epoch from which to load the optimizer state.
         """
         filename = self.get_epoch_model_filename(epoch=epoch - 1) + ".opt.pt"
-        self._updater.load_optimizer(filename, device=self._device)
+        if (os.path.isfile(filename)):
+            self._updater.load_optimizer(filename, device=self._device)
+        else:
+            print("Warning: No optimizer state for the given checkpoint could be loaded. Continuing training with a fresh optimizer...", file=log.v4)
 
     def _save_optimizer(self):
         """

--- a/returnn/torch/engine.py
+++ b/returnn/torch/engine.py
@@ -524,7 +524,7 @@ class Engine(EngineBase):
         filename = self.get_epoch_model_filename(epoch=epoch - 1) + ".opt.pt"
         if os.path.isfile(filename):
             self._updater.load_optimizer(filename, device=self._device)
-        elif self.config.bool("allow_missing_optimizer", False):
+        elif self.config.bool("allow_missing_optimizer_checkpoint", False):
             print(
                 "Warning: No optimizer state for the given checkpoint could be loaded. Continuing training with a fresh optimizer...",
                 file=log.v4,

--- a/returnn/torch/engine.py
+++ b/returnn/torch/engine.py
@@ -189,7 +189,7 @@ class Engine(EngineBase):
             )
 
             if self.config.bool("stop_on_nonfinite_train_score", True):
-                self.check_nonfinite_train_score(losses_dict, accumulated_losses_dict)
+                self._check_nonfinite_train_score(losses_dict, accumulated_losses_dict)
 
             accumulated_losses_dict += losses_dict
             accumulated_inv_norm_dict += inv_norm_dict
@@ -550,7 +550,7 @@ class Engine(EngineBase):
             if os.path.isfile(filename):
                 os.unlink(filename)
 
-    def check_nonfinite_train_score(self, scores: Dict, accumulated_scores=None):
+    def _check_nonfinite_train_score(self, scores: Dict, accumulated_scores=None):
         if any((math.isnan(v) or math.isinf(v)) for v in scores.values()):
             print("Model seems broken, got inf or nan loss.", file=log.v1)
             if accumulated_scores is not None:

--- a/returnn/torch/engine.py
+++ b/returnn/torch/engine.py
@@ -521,7 +521,7 @@ class Engine(EngineBase):
         filename = self.get_epoch_model_filename(epoch=epoch - 1) + ".opt.pt"
         if os.path.isfile(filename):
             self._updater.load_optimizer(filename, device=self._device)
-        elif self.config.bool("use_fresh_optimizer_for_missing_checkpoint", False):
+        elif self.config.bool("allow_missing_optimizer", False):
             print(
                 "Warning: No optimizer state for the given checkpoint could be loaded. Continuing training with a fresh optimizer...",
                 file=log.v4,
@@ -550,7 +550,13 @@ class Engine(EngineBase):
             if os.path.isfile(filename):
                 os.unlink(filename)
 
-    def _check_nonfinite_train_score(self, scores: Dict, accumulated_scores=None):
+    def _check_nonfinite_train_score(self, scores: Dict, accumulated_scores: Dict = None):
+        """
+        Checks if the score dictionary contains any nan or inf values
+        :param scores: Dict containing score values
+        :param accumulated_scores (optional): Dict containing accumulated score values. Defaults to None
+        :raises Exception if nan or inf value is found.
+        """
         if any((math.isnan(v) or math.isinf(v)) for v in scores.values()):
             print("Model seems broken, got inf or nan loss.", file=log.v1)
             if accumulated_scores is not None:


### PR DESCRIPTION
The changes have two effects:

1. If during training one of the loss values becomes `nan` or `inf` the training breaks if the according flag `stop_on_nonfinite_train_score` is set in the config.
2. If a training is started and uses an existing checkpoint it also starts if the corresponding optimizer checkpoint can't be found. This makes it possible to go back several epochs but the optimizers have been cleaned.