### PR TITLE
Add step, epoch to RunCTX, replace init with load

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,54 @@
+Changelog
+=========
+
+
+
+Current Master (0.1+git)
+------------------------
+
+ - provide ``epoch`` and ``step`` in ``RunCtx`` (`https://github.com/JackTemaki/MiniReturnn/pull/4`_)
+
+Version 0.1
+-----------
+
+This part is taken from the readme at time of tagging v0.1.
+
+Removed features:
+ - Anything related to the Tensorflow backend (also tools and tests)
+ - Anything related to the Frontend API
+ - Window/Chunking/Batching logic WITHIN DATASETS (Batching and Chunking exists in the new PyTorch datapipeline)
+ - Some older Datasets that depended on removed features (no relevant Dataset should be missing)
+ - Most utility code that was only used by Tensorflow code
+ - There is no default keep-pattern of checkpoints, ``keep`` has to specified within the ``cleanup_old_models`` config dict explicitely
+ - "eval" dataset is no longer allowed, use "eval_datasets" instead
+ - ``__main__.py`` no longer handles datasets
+ - "hdf_dump" no longer allows strings but only config files, dumps only "train" (which it probably also did before).
+
+
+Not yet added features:
+ - Multi-GPU training
+
+
+Changed behavior:
+ - The data to the actual step function in the config is passed as PyTorch tensor dict instead of Frontend Tensors
+   - Axis information is automatically added as ``<data_name>:size<idx>`` entry starting from 0 = batch axis
+   - Axis information is always placed on the target device
+ - The Loss class has less parameters, e.g. ``use_normalization`` does not exist, and the behavior is always true.
+   -  Also determining the inverse norm factor automatically is not possible, it has to be provided explictly
+ - The Engine API is regarding step functions is structured slightly differently
+ - Step-logging is slightly differently
+ - Overriding the Engine by declaring a ``CustomEngine`` in the config is possible, see https://github.com/rwth-i6/returnn/pull/1306 for a discussion on this.
+ - ``weight_decay`` is applied to ALL parameters without exception, some discussion in https://github.com/rwth-i6/returnn/issues/1319 ,
+    although the conclusion that the mainline RETURNN behavior can be non-deterministic was not reached there.
+ - Always uses the cache-manager if available, even when not running in cluster
+ - Dataloader2 from ``torchdata`` was replaced by Dataloader from ``torch.utils.data``, as Dataloader2 has a non-stable API. In addition, num_workers=1 with "spawn" multiprocessing is set. This means that an extra process loads the data, and prefetch is working correctly, resulting in significant speedups.
+
+
+Added features that are likely to appear in mainline-RETURNN:
+ - Checkpoint cleanup, currently pending for mainline RETURNN in https://github.com/rwth-i6/returnn/pull/1316
+ - seq_tag, seq_idx and non-Tensor data support in the data pipeline, pending at: https://github.com/rwth-i6/returnn/pull/1330
+
+
+Experimental features that might not be needed:
+ - ``batching_drop_last`` config parameter to discard the last incomplete batch in an epoch
+ - forward init/finish hooks that can be used to attach custom objects to the run_ctx

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Changelog
 Current Master (0.1+git)
 ------------------------
 
- - provide ``epoch`` and ``step`` in ``RunCtx`` (`https://github.com/JackTemaki/MiniReturnn/pull/4`_)
+- provide ``epoch`` and ``step`` in ``RunCtx`` (`<https://github.com/JackTemaki/MiniReturnn/pull/4>`_)
 
 Version 0.1
 -----------
@@ -39,7 +39,7 @@ Changed behavior:
  - Step-logging is slightly differently
  - Overriding the Engine by declaring a ``CustomEngine`` in the config is possible, see https://github.com/rwth-i6/returnn/pull/1306 for a discussion on this.
  - ``weight_decay`` is applied to ALL parameters without exception, some discussion in https://github.com/rwth-i6/returnn/issues/1319 ,
-    although the conclusion that the mainline RETURNN behavior can be non-deterministic was not reached there.
+   although the conclusion that the mainline RETURNN behavior can be non-deterministic was not reached there.
  - Always uses the cache-manager if available, even when not running in cluster
  - Dataloader2 from ``torchdata`` was replaced by Dataloader from ``torch.utils.data``, as Dataloader2 has a non-stable API. In addition, num_workers=1 with "spawn" multiprocessing is set. This means that an extra process loads the data, and prefetch is working correctly, resulting in significant speedups.
 

--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ Changed behavior:
  - Step-logging is slightly differently
  - Overriding the Engine by declaring a ``CustomEngine`` in the config is possible, see https://github.com/rwth-i6/returnn/pull/1306 for a discussion on this.
  - ``weight_decay`` is applied to ALL parameters without exception, some discussion in https://github.com/rwth-i6/returnn/issues/1319 ,
-    although the conclusion that the mainline RETURNN behavior can be non-deterministic was not reached there.
+   although the conclusion that the mainline RETURNN behavior can be non-deterministic was not reached there.
  - Always uses the cache-manager if available, even when not running in cluster
  - Dataloader2 from ``torchdata`` was replaced by Dataloader from ``torch.utils.data``, as Dataloader2 has a non-stable API. In addition, num_workers=1 with "spawn" multiprocessing is set. This means that an extra process loads the data, and prefetch is working correctly, resulting in significant speedups.
 

--- a/returnn/__setup__.py
+++ b/returnn/__setup__.py
@@ -8,7 +8,7 @@ import os
 import sys
 
 
-VERSION = "0.1+prerelease+git"
+VERSION = "0.1+git"
 
 _my_dir = os.path.dirname(os.path.abspath(__file__))
 # Use realpath to resolve any symlinks. We want the real root-dir, to be able to check the Git revision.

--- a/returnn/torch/engine.py
+++ b/returnn/torch/engine.py
@@ -163,7 +163,7 @@ class Engine(EngineBase):
         epoch_start_time = time.time()
 
         self._model.train()
-        init_train_step_run_ctx(device=self._device, engine=self)
+        init_train_step_run_ctx(device=self._device, engine=self, epoch=self.epoch)
 
         accumulated_losses_dict = NumbersDict()
         accumulated_inv_norm_dict = NumbersDict()
@@ -216,7 +216,7 @@ class Engine(EngineBase):
         Runs model on all eval datasets and calculates the loss.
         """
         self._model.eval()
-        init_train_step_run_ctx(device=self._device, engine=self)
+        init_train_step_run_ctx(device=self._device, engine=self, epoch=self.epoch)
 
         for dataset_name, dataset in self.eval_datasets.items():
             dataset_start_time = time.time()
@@ -277,7 +277,8 @@ class Engine(EngineBase):
         Runs the model
         """
         self._model.eval()
-        init_forward_step_run_ctx(device=self._device, engine=self)
+        self.epoch = self._start_epoch
+        init_forward_step_run_ctx(device=self._device, engine=self, epoch=self.epoch)
 
         if forward_init_hook := self.config.typed_value("forward_init_hook", None):
             assert callable(forward_init_hook)

--- a/returnn/torch/engine.py
+++ b/returnn/torch/engine.py
@@ -24,7 +24,7 @@ from returnn.util import NumbersDict
 from .updater import Updater
 from .data import pipeline as data_pipeline
 from .data import returnn_dataset_wrapper
-from .context import get_run_ctx, init_train_step_run_ctx, init_forward_step_run_ctx, RunCtx, Loss
+from .context import get_run_ctx, init_load_run_ctx, init_train_step_run_ctx, init_forward_step_run_ctx, RunCtx, Loss
 
 
 class Engine(EngineBase):
@@ -172,7 +172,7 @@ class Engine(EngineBase):
             step_time_start = time.time()
 
             run_ctx = get_run_ctx()
-            run_ctx.init_step()
+            run_ctx.init_step(self._train_step)
 
             total_loss, ctx_losses_dict = self.run_train_step(data, run_ctx)
 
@@ -232,7 +232,7 @@ class Engine(EngineBase):
                 for data in data_loader:
                     step_time_start = time.time()
                     run_ctx = get_run_ctx()
-                    run_ctx.init_step()
+                    run_ctx.init_step(self._train_step)
 
                     total_loss, ctx_losses_dict = self.run_eval_step(data, run_ctx)
 
@@ -293,7 +293,7 @@ class Engine(EngineBase):
             for data in data_loader:
                 step_time_start = time.time()
                 run_ctx = get_run_ctx()
-                run_ctx.init_step()
+                run_ctx.init_step(self._train_step)
 
                 self.run_forward_step(data, run_ctx)
 
@@ -425,6 +425,8 @@ class Engine(EngineBase):
         random_seed = self.config.int("random_seed", 42)
         random_seed = (epoch * 193939 + step * 19937 + random_seed * 27644437 + 479001599) % (2**31)
         torch.manual_seed(random_seed)
+
+        init_load_run_ctx(device=self._device, engine=self, epoch=epoch)
 
         get_model_func = self.config.typed_value("get_model")
         assert get_model_func, "get_model not defined"


### PR DESCRIPTION
step and epoch are currently only passed to the init function of the Model, 
now we also pass this to the `RunCtx` to be accessible everywhere in order
to do e.g. epoch or step based loss scaling.

Note: epoch based parameter changes are still not supported!