### PR TITLE
loading via 'load' for forward fix

### DIFF
--- a/returnn/engine/base.py
+++ b/returnn/engine/base.py
@@ -148,8 +148,8 @@ class EngineBase(object):
                 config.value("load", ""),
                 load_model_epoch_filename + cls.get_file_postfix(),
             )
-            # If "load" is given and "model" is not, always load explicitly
-            if config.value("model", None) is None:
+            # If "load" is given and we are not training, always load explicitly
+            if config.value("task", "train") != "train":
                 return None, load_model_epoch_filename
 
         import_model_train_epoch1 = util.get_checkpoint_filepattern(config.value("import_model_train_epoch1", ""))

--- a/returnn/engine/base.py
+++ b/returnn/engine/base.py
@@ -148,6 +148,9 @@ class EngineBase(object):
                 config.value("load", ""),
                 load_model_epoch_filename + cls.get_file_postfix(),
             )
+            # If "load" is given and "model" is not, always load explicitly
+            if config.value("model", None) is None:
+                return None, load_model_epoch_filename
 
         import_model_train_epoch1 = util.get_checkpoint_filepattern(config.value("import_model_train_epoch1", ""))
         if import_model_train_epoch1:

--- a/returnn/torch/engine.py
+++ b/returnn/torch/engine.py
@@ -413,7 +413,7 @@ class Engine(EngineBase):
         with autocast(device_type=self._device, dtype=self._amp_dtype) if self._amp_dtype else nullcontext():
             self._forward_step_func(model=self._model, data=data, run_ctx=run_ctx, **sentinel_kw)
 
-    def _load_model(self, *, epoch: int, filename: Optional[str] = None):
+    def _load_model(self, *, epoch: Optional[int], filename: Optional[str] = None):
         """
         Sets self._model to a torch.nn.Module.
 
@@ -431,6 +431,10 @@ class Engine(EngineBase):
             )
             step = checkpoint_state["step"]
             self._start_epoch = self._final_epoch = checkpoint_state["epoch"]
+            if epoch is None:
+                epoch = self._start_epoch
+            else:
+                assert epoch == self._start_epoch
         elif epoch is not None and epoch > 1:
             filename = self.get_epoch_model_filename(epoch=epoch - 1) + ".pt"
             print("Load model %s" % (filename,), file=log.v4)


### PR DESCRIPTION
A small fix before pinning version 0.2, the bigger changes of #7 can come afterwards for the next one.

 - directly return get_epoch_model if 'load' is used
 - make epoch in _load_model Optional
 - set epoch based on checkpoint file