### PR TITLE
Add internal cache manager

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+Current Master (0.3+git)
+------------------------
+
+- Added temporary file cache manager (activated via `use_cache_manager` as for the i6 specific caching)
+
+
 
 Version 0.3
 -----------

--- a/returnn/__setup__.py
+++ b/returnn/__setup__.py
@@ -8,7 +8,7 @@ import os
 import sys
 
 
-VERSION = "0.3"
+VERSION = "0.3+git"
 
 _my_dir = os.path.dirname(os.path.abspath(__file__))
 # Use realpath to resolve any symlinks. We want the real root-dir, to be able to check the Git revision.

--- a/returnn/torch/engine.py
+++ b/returnn/torch/engine.py
@@ -13,7 +13,6 @@ import time
 import torch
 import torch.utils.data.datapipes as dp
 from torch import autocast, Tensor
-from torch.cuda import amp
 from torch.utils.data import DataLoader
 from random import random
 import math

--- a/returnn/util/basic.py
+++ b/returnn/util/basic.py
@@ -2460,6 +2460,7 @@ def cf(filename):
     shutil.copy(real_filename, temp_file)
     _tempdir_cache[filename] = temp_file
 
+    return temp_file
 
 def binary_search_any(cmp, low, high):
     """

--- a/returnn/util/basic.py
+++ b/returnn/util/basic.py
@@ -2462,6 +2462,7 @@ def cf(filename):
 
     return temp_file
 
+
 def binary_search_any(cmp, low, high):
     """
     Binary search for a custom compare function.


### PR DESCRIPTION
Returnn internally manages cached files in the default tmp dir in case the i6 cache manager is not available.

No cleanup will be done automatically, as the files should be considered semi-persistent.